### PR TITLE
Add gif.abort implementation to cancel previous gif rendering before rendering new gif

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,7 +507,8 @@ class Canvas {
       		copy: true,
       		delay: 100
     	});
-  	});
+    });
+    gif.abort()
   	gif.render();
   }
 


### PR DESCRIPTION
Found out from another Redditor that gif.js has a function gif.abort, which cancels the rendering of the currently rendering gif. Tested this and it worked, so I added it to the code. The formatting refuses to work correctly though - I've been trying for around half an hour with multiple branches to get the two lines to line up properly but they just won't. I hope this isn't an issue, as I can't seem to figure out how to align it.